### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded G4F API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Gemini API key (example)
 GEMINI_API_KEY=YOUR_GEMINI_API_KEY
 
+# G4F API key (for g4f-main provider)
+VITE_G4F_API_KEY=
+
 # Supabase public client settings
 VITE_PUBLIC_SUPABASE_URL=https://jnfnqtohljybohlcslnm.supabase.co
 VITE_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_b_1TgVIi1GxWG4Oy1X9Trw_UoM8Y5EW

--- a/features/chat/components/settings/GeneralTab.tsx
+++ b/features/chat/components/settings/GeneralTab.tsx
@@ -5,7 +5,7 @@ import { Trash2, Key, Cpu, Eye, EyeOff, ExternalLink, Globe, Server, Info, Shiel
 import { ChatSettings, AIProvider, G4FSubProvider } from '../../../../types';
 import { SectionHeader } from './Shared';
 import { type SpendingInfo } from '../../../../lib/supabase/aiService';
-import { G4F_PROVIDERS, fetchG4FModels, searchModels, testG4FProvider, getG4FProvider, DEFAULT_G4F_API_KEY, type G4FProviderConfig } from '../../../../lib/g4fService';
+import { G4F_PROVIDERS, fetchG4FModels, searchModels, testG4FProvider, getG4FProvider, type G4FProviderConfig } from '../../../../lib/g4fService';
 
 interface GeneralTabProps {
   settings: ChatSettings;
@@ -98,7 +98,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({ settings, setSettings, o
         g4f: {
           subProvider: 'pollinations',
           model: 'openai',
-          apiKey: DEFAULT_G4F_API_KEY,
+          apiKey: import.meta.env.VITE_G4F_API_KEY || '',
           streaming: true,
           webSearch: false
         }

--- a/hooks/useGeminiAI.ts
+++ b/hooks/useGeminiAI.ts
@@ -7,7 +7,7 @@ import { getInitialTools } from '../lib/aiTools';
 import { executeTool } from '../lib/toolExecutor';
 import { universalChat } from '../lib/universalAI';
 import { azureChat, toAzureMessages, AISpendingLimitError, AIAuthError, getSpendingInfo, type SpendingInfo } from '../lib/supabase/aiService';
-import { g4fChat, g4fChatStream, getG4FProvider, DEFAULT_G4F_API_KEY, type G4FChatRequest, type G4FContentPart, type G4FMessage } from '../lib/g4fService';
+import { g4fChat, g4fChatStream, getG4FProvider, type G4FChatRequest, type G4FContentPart, type G4FMessage } from '../lib/g4fService';
 
 // --- Configuration ---
 const MAX_HISTORY_LENGTH = 20;
@@ -176,7 +176,7 @@ export const useGeminiAI = (setPage?: (page: Page) => void) => {
     g4f: {
       subProvider: 'pollinations',
       model: 'openai',
-      apiKey: DEFAULT_G4F_API_KEY,
+      apiKey: import.meta.env.VITE_G4F_API_KEY || '',
       streaming: true,
       webSearch: false
     }
@@ -463,7 +463,7 @@ ${recentContext}
           messages: g4fMessages,
           temperature: settings.temperature,
           maxTokens: 4096,
-          apiKey: g4fSettings.apiKey || (g4fSettings.subProvider === 'g4f-main' ? DEFAULT_G4F_API_KEY : undefined),
+          apiKey: g4fSettings.apiKey || (g4fSettings.subProvider === 'g4f-main' ? import.meta.env.VITE_G4F_API_KEY : undefined),
           customBaseUrl: g4fSettings.customBaseUrl,
           signal: abortControllerRef.current?.signal,
           providerOptions: {

--- a/lib/g4fService.ts
+++ b/lib/g4fService.ts
@@ -373,7 +373,7 @@ function resolveProviderEndpoint(
   };
 
   // G4F gateway doesn't require auth for most providers
-  const authKey = apiKey || (provider === 'g4f-main' ? DEFAULT_G4F_API_KEY : undefined);
+  const authKey = apiKey || (provider === 'g4f-main' ? import.meta.env.VITE_G4F_API_KEY : undefined);
   if ((config.requiresAuth || provider === 'g4f-main') && authKey) {
     headers['Authorization'] = `Bearer ${authKey}`;
   }
@@ -768,5 +768,3 @@ export function clearModelCache(provider?: G4FSubProvider): void {
   }
 }
 
-// Default G4F API key (can be overridden by user)
-export const DEFAULT_G4F_API_KEY = 'g4f_u_mk4lyf_6acb6461af049be7b75e638d8f7f7d6a262504574eaccf57_c3e14805';

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
     readonly VITE_SUPABASE_URL: string
     readonly VITE_SUPABASE_ANON_KEY: string
     readonly VITE_G4F_API_URL: string
+    readonly VITE_G4F_API_KEY: string
     // more env variables...
 }
 


### PR DESCRIPTION
Sentinel 🛡️ Security Fix:
Removed hardcoded `DEFAULT_G4F_API_KEY` to prevent secret leakage.
This key was exposed in `lib/g4fService.ts` and used as a fallback.
Replaced it with `VITE_G4F_API_KEY` environment variable.

Severity: CRITICAL
Vulnerability: Hardcoded API Key
Impact: Unauthorized access to G4F services if the key is valid.
Fix: Use environment variables.
Verification: Grep for `DEFAULT_G4F_API_KEY` returns no results. Build passes.

---
*PR created automatically by Jules for task [17829419758914997331](https://jules.google.com/task/17829419758914997331) started by @PrinceJonaa*