### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API Key Leak in Build

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Accidental Secret Leaks via Vite Define
+**Vulnerability:** A server-side API key (`GEMINI_API_KEY`) was being injected into the client-side bundle via `vite.config.ts` using the `define` property. This effectively made the secret public to anyone inspecting the frontend code.
+**Learning:** Vite's `define` feature performs static replacement during the build. If you map a `process.env` variable to a value from the build environment, that value is hardcoded into the output JavaScript.
+**Prevention:** Never use `define` to inject secrets. Use `import.meta.env` with `VITE_` prefix only for intentionally public variables. For secrets, keep them strictly server-side (e.g., in Supabase Edge Functions) and proxy requests.

--- a/hooks/useGeminiAI.ts
+++ b/hooks/useGeminiAI.ts
@@ -231,7 +231,7 @@ export const useGeminiAI = (setPage?: (page: Page) => void) => {
   // Initialize Google AI Client if needed
   useEffect(() => {
     if (settings.provider === 'google') {
-      const apiKey = settings.customApiKey || process.env.API_KEY;
+      const apiKey = settings.customApiKey;
       if (apiKey) {
         aiClientRef.current = new GoogleGenAI({ apiKey });
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,10 +10,6 @@ export default defineConfig(({ mode }) => {
         host: '0.0.0.0',
       },
       plugins: [react()],
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix API Key Leak in Build

🚨 Severity: CRITICAL
💡 Vulnerability: The `vite.config.ts` file was using `define` to inject the server-side `GEMINI_API_KEY` into `process.env.API_KEY` and `process.env.GEMINI_API_KEY` in the client bundle. This exposed the API key to anyone inspecting the production JavaScript files.
🎯 Impact: If a developer built the app with `GEMINI_API_KEY` in their environment, that key would become public, potentially leading to quota theft or abuse.
🔧 Fix: Removed the `define` block from `vite.config.ts` and the fallback logic in `hooks/useGeminiAI.ts`.
✅ Verification: Ran `grep` to confirm no remaining usage of `process.env.API_KEY` or `process.env.GEMINI_API_KEY`. Ran `pnpm build` to ensure the application still builds correctly.

---
*PR created automatically by Jules for task [11432676518668375004](https://jules.google.com/task/11432676518668375004) started by @PrinceJonaa*