### PR TITLE
Shield: Replace eval with direct function execution for built-in tools

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** A server-side API key (`GEMINI_API_KEY`) was being injected into the client-side bundle via `vite.config.ts` using the `define` property. This effectively made the secret public to anyone inspecting the frontend code.
 **Learning:** Vite's `define` feature performs static replacement during the build. If you map a `process.env` variable to a value from the build environment, that value is hardcoded into the output JavaScript.
 **Prevention:** Never use `define` to inject secrets. Use `import.meta.env` with `VITE_` prefix only for intentionally public variables. For secrets, keep them strictly server-side (e.g., in Supabase Edge Functions) and proxy requests.
+
+## 2024-05-23 - Unnecessary Use of Eval for Internal Tools
+**Vulnerability:** The `executeTool` function used `new Function` to execute internal tool logic by reconstructing function bodies from strings. This created an unnecessary Remote Code Execution (RCE) sink.
+**Learning:** Serializing function bodies to strings and re-evaluating them is brittle (breaks with closures/minification) and insecure.
+**Prevention:** Pass direct function references (`implementation` field) for static/built-in tools. Reserve `eval`/`new Function` strictly for sandboxed user-generated code (if absolutely necessary and properly isolated).

--- a/hooks/useGeminiAI.ts
+++ b/hooks/useGeminiAI.ts
@@ -379,7 +379,7 @@ ${recentContext}
                     if (setPage) { setPage(dest as Page); result = { success: true }; }
                   } else {
                     const toolDef = activeTools.find(t => t.name === call.name);
-                    if (toolDef) result = executeTool(toolDef.code, call.args);
+                    if (toolDef) result = executeTool(toolDef.code, call.args, toolDef.implementation);
                   }
                   toolResultsRecord.push({ name: call.name, result });
                   toolOutputs.push({ functionResponse: { name: call.name, response: result } });

--- a/lib/aiTools.ts
+++ b/lib/aiTools.ts
@@ -884,6 +884,7 @@ export function getInitialTools(): ToolDefinition[] {
       description: decl.description || '',
       parameters: JSON.stringify(decl.parameters, null, 2),
       code: code,
+      implementation: fn,
       enabled: true,
       alwaysOn: false
     };

--- a/types.ts
+++ b/types.ts
@@ -261,6 +261,7 @@ export interface ToolDefinition {
   description: string;
   parameters: string; // JSON schema string
   code: string; // Function body string
+  implementation?: (...args: any[]) => any; // Actual function reference (safer execution)
   enabled: boolean;
   alwaysOn?: boolean;
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Unsafe Eval Usage

🚨 Severity: HIGH (Defense in Depth / RCE Mitigation)
💡 Vulnerability: The `executeTool` function used `new Function` (eval) to execute built-in tools by reconstructing their bodies from strings. This created an unnecessary Remote Code Execution (RCE) sink and was brittle.
🎯 Impact: While currently internal, this pattern is a dangerous precedent and a potential vector for Code Injection if tool definitions were ever loaded dynamically from an untrusted source.
🔧 Fix: 
- Refactored `executeTool` to accept a direct function reference (`implementation`).
- Updated `getInitialTools` to attach the original function to the tool definition.
- `executeTool` now prefers direct execution (safer, faster, retains closure scope) and falls back to `new Function` only for legacy/dynamic cases.
✅ Verification: `pnpm build` passes successfully. Code logic ensures backward compatibility while securing the primary path.

---
*PR created automatically by Jules for task [6358848999707541623](https://jules.google.com/task/6358848999707541623) started by @PrinceJonaa*