### PR TITLE
🛡️ Sentinel: Secure Tool Execution via Function References

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** A server-side API key (`GEMINI_API_KEY`) was being injected into the client-side bundle via `vite.config.ts` using the `define` property. This effectively made the secret public to anyone inspecting the frontend code.
 **Learning:** Vite's `define` feature performs static replacement during the build. If you map a `process.env` variable to a value from the build environment, that value is hardcoded into the output JavaScript.
 **Prevention:** Never use `define` to inject secrets. Use `import.meta.env` with `VITE_` prefix only for intentionally public variables. For secrets, keep them strictly server-side (e.g., in Supabase Edge Functions) and proxy requests.
+
+## 2024-05-24 - Unnecessary Use of 'eval' (new Function) for Trusted Tools
+**Vulnerability:** The application was using `new Function` (effectively `eval`) to execute all AI tool logic, including built-in tools. While this is necessary for user-customized tools, it unnecessarily expanded the attack surface for built-in, trusted tools.
+**Learning:** Hardcoding tool logic as strings and re-hydrating them via `new Function` bypasses static analysis and creates risk if the string source is ever compromised.
+**Prevention:** Implement a hybrid execution model. Use direct function references for trusted, static tools (Secure Path) and reserve dynamic evaluation only for user-edited code (Dynamic Path). Ensure the secure path is invalidated if the user edits the code.

--- a/features/chat/components/ToolEditor.tsx
+++ b/features/chat/components/ToolEditor.tsx
@@ -32,7 +32,8 @@ export const ToolEditor: React.FC<ToolEditorProps> = ({ tool, onSave, onCancel, 
      const result = await generateRaw(prompt);
      if (result) {
         const clean = result.replace(/^```javascript|```$/g, '').replace(/^```|```$/g, '').trim();
-        setForm({...form, code: clean});
+        // Clear secure implementation when code is modified by AI
+        setForm({...form, code: clean, implementation: undefined});
         setStatus("Optimized!");
         setTimeout(() => setStatus(""), 2000);
      } else {
@@ -107,7 +108,8 @@ export const ToolEditor: React.FC<ToolEditorProps> = ({ tool, onSave, onCancel, 
                   <textarea 
                     className="w-full h-full bg-[#0d0d0d] p-6 text-green-400 font-mono text-sm leading-relaxed outline-none resize-none" 
                     value={form.code} 
-                    onChange={e => setForm({...form, code: e.target.value})} 
+                    // Clear secure implementation when code is manually modified
+                    onChange={e => setForm({...form, code: e.target.value, implementation: undefined})}
                     spellCheck={false} 
                   />
                </div>

--- a/hooks/useGeminiAI.ts
+++ b/hooks/useGeminiAI.ts
@@ -379,7 +379,7 @@ ${recentContext}
                     if (setPage) { setPage(dest as Page); result = { success: true }; }
                   } else {
                     const toolDef = activeTools.find(t => t.name === call.name);
-                    if (toolDef) result = executeTool(toolDef.code, call.args);
+                    if (toolDef) result = executeTool(toolDef, call.args);
                   }
                   toolResultsRecord.push({ name: call.name, result });
                   toolOutputs.push({ functionResponse: { name: call.name, response: result } });

--- a/lib/aiTools.ts
+++ b/lib/aiTools.ts
@@ -885,7 +885,8 @@ export function getInitialTools(): ToolDefinition[] {
       parameters: JSON.stringify(decl.parameters, null, 2),
       code: code,
       enabled: true,
-      alwaysOn: false
+      alwaysOn: false,
+      implementation: fn // Secure execution: pass function reference if available
     };
   });
 }

--- a/lib/toolExecutor.ts
+++ b/lib/toolExecutor.ts
@@ -2,8 +2,34 @@
 import { db } from './mockDb';
 import * as frameworkEngine from './frameworkEngine';
 import { levenshteinDistance } from './aiTools';
+import { ToolDefinition } from '../types';
 
-export const executeTool = (code: string, args: any) => {
+export const executeTool = (toolSource: string | ToolDefinition, args: any) => {
+    // 1. Secure Path: Use pre-compiled implementation if available
+    // This avoids 'new Function' (eval) for built-in tools, improving security
+    if (typeof toolSource === 'object' && toolSource.implementation) {
+        try {
+             const executionResult = toolSource.implementation(args);
+
+             // Parse result if it's a string json
+             if (typeof executionResult === 'string') {
+                try {
+                    return JSON.parse(executionResult);
+                } catch {
+                    return { result: executionResult };
+                }
+            }
+            return executionResult;
+        } catch (err: any) {
+             console.error("Tool Execution Error (Secure):", err);
+             return { error: err.message };
+        }
+    }
+
+    // 2. Dynamic Path: Fallback for custom/edited tools
+    // This uses 'new Function', which is necessary for user-defined logic
+    const code = typeof toolSource === 'string' ? toolSource : toolSource.code;
+
     // Helper object containing all imports
     const utils = {
         analyzeJournalEntry: frameworkEngine.analyzeJournalEntry,
@@ -38,7 +64,7 @@ export const executeTool = (code: string, args: any) => {
         }
         return executionResult;
     } catch (err: any) {
-        console.error("Tool Execution Error:", err);
+        console.error("Tool Execution Error (Dynamic):", err);
         return { error: err.message };
     }
 };

--- a/types.ts
+++ b/types.ts
@@ -263,6 +263,7 @@ export interface ToolDefinition {
   code: string; // Function body string
   enabled: boolean;
   alwaysOn?: boolean;
+  implementation?: Function; // Secure execution path
 }
 
 export interface ContactMessage {


### PR DESCRIPTION
This PR enhances the security of the AI tool execution engine. Previously, all tools (including trusted built-in ones) were executed using `new Function`, which is effectively `eval`. 

This change introduces a **Secure Execution Path**:
1.  **Built-in Tools**: Now carry a direct reference to their implementation function. `executeTool` checks for this reference and calls it directly, bypassing the `new Function` constructor entirely.
2.  **Custom/Edited Tools**: If a user edits a tool's code in the UI, the `implementation` reference is removed. `executeTool` then falls back to the **Dynamic Path** (using `new Function`) to execute the custom logic.

This reduces the attack surface by minimizing the usage of `eval`-like constructs for the majority of tool executions.

---
*PR created automatically by Jules for task [7153853043410713887](https://jules.google.com/task/7153853043410713887) started by @PrinceJonaa*