### PR TITLE
🎨 Palette: Improve notification accessibility and feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - [Toast Accessibility & Visual Feedback]
 **Learning:** Standard toast notifications often lack intrinsic accessibility attributes (role, aria-live) and visual duration indicators, making them confusing for screen readers and cognitively demanding for sighted users who must guess when the message disappears.
 **Action:** Always couple auto-dismiss logic with a visual timer (progress bar) and strictly map toast types to semantic roles (error -> alert, info -> status) to ensure inclusive communication.
+
+## 2024-05-25 - [List Item Action Context]
+**Learning:** In lists of items (like notifications), generic action labels like "Mark as read" or "Open link" are unhelpful for screen reader users who may not know which item the action belongs to when tabbing through.
+**Action:** Always include the item's unique identifier (like title) in the `aria-label` of actions (e.g., "Mark notification 'Welcome' as read") to provide necessary context.

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -4,7 +4,7 @@
  * Shows unread count and recent notifications
  */
 import { useState, useEffect, useRef } from 'react';
-import { Bell, Check, X, ExternalLink } from 'lucide-react';
+import { Bell, Check, X, ExternalLink, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { notificationService, Notification } from '../lib/supabase/notificationService';
@@ -80,7 +80,7 @@ export function NotificationBell() {
             <button
                 onClick={() => setIsOpen(!isOpen)}
                 className="relative p-2 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-white/10"
-                aria-label="Notifications"
+                aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : 'Notifications, no unread messages'}
             >
                 <Bell size={20} />
                 {unreadCount > 0 && (
@@ -106,8 +106,9 @@ export function NotificationBell() {
                                 <button
                                     onClick={handleMarkAllRead}
                                     disabled={loading}
-                                    className="text-xs text-accent hover:underline disabled:opacity-50"
+                                    className="text-xs text-accent hover:underline disabled:opacity-50 flex items-center gap-1"
                                 >
+                                    {loading && <Loader2 size={12} className="animate-spin" />}
                                     Mark all read
                                 </button>
                             )}
@@ -116,7 +117,7 @@ export function NotificationBell() {
                         {/* Notifications List */}
                         <div className="max-h-80 overflow-y-auto">
                             {notifications.length === 0 ? (
-                                <div className="py-8 text-center text-gray-500">
+                                <div className="py-8 text-center text-gray-500" role="status">
                                     <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />
                                     <p className="text-sm">No notifications yet</p>
                                 </div>
@@ -150,8 +151,8 @@ export function NotificationBell() {
                                                         to={notif.link}
                                                         onClick={() => setIsOpen(false)}
                                                         className="p-1 text-gray-500 hover:text-accent"
-                                                        aria-label="Open link"
-                                                        title="Open link"
+                                                        aria-label={`Open link for "${notif.title}"`}
+                                                        title={`Open link for "${notif.title}"`}
                                                     >
                                                         <ExternalLink size={14} aria-hidden="true" />
                                                     </Link>
@@ -161,7 +162,7 @@ export function NotificationBell() {
                                                         onClick={() => handleMarkAsRead(notif.id)}
                                                         className="p-1 text-gray-500 hover:text-green-400"
                                                         title="Mark as read"
-                                                        aria-label="Mark as read"
+                                                        aria-label={`Mark notification "${notif.title}" as read`}
                                                     >
                                                         <Check size={14} aria-hidden="true" />
                                                     </button>


### PR DESCRIPTION
💡 **What**: Added dynamic ARIA labels to the notification bell and list items, a loading spinner to the "Mark all read" button, and proper roles for empty states.
🎯 **Why**: Screen reader users could not distinguish between actions for different notifications, and sighted users lacked feedback when clearing notifications.
♿ **Accessibility**: Added context to "Mark as read"/"Open link" labels, added unread count to bell label, and used role="status" for empty state.

---
*PR created automatically by Jules for task [17018819331395696171](https://jules.google.com/task/17018819331395696171) started by @PrinceJonaa*