### PR TITLE
🎨 Palette: Add 'Close on Escape' to notification dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - [Toast Accessibility & Visual Feedback]
 **Learning:** Standard toast notifications often lack intrinsic accessibility attributes (role, aria-live) and visual duration indicators, making them confusing for screen readers and cognitively demanding for sighted users who must guess when the message disappears.
 **Action:** Always couple auto-dismiss logic with a visual timer (progress bar) and strictly map toast types to semantic roles (error -> alert, info -> status) to ensure inclusive communication.
+
+## 2024-05-25 - [Dropdown Keyboard Accessibility]
+**Learning:** Custom dropdowns often trap keyboard users or force them to navigate away to close the menu, disrupting the flow.
+**Action:** Always implement a "Close on Escape" handler that restores focus to the trigger button, and ensure ARIA attributes (`aria-expanded`, `aria-haspopup`) are dynamically updated.

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -15,19 +15,36 @@ export function NotificationBell() {
     const [unreadCount, setUnreadCount] = useState(0);
     const [loading, setLoading] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
 
     useEffect(() => {
         loadNotifications();
+    }, []);
 
+    useEffect(() => {
         // Close on outside click
         function handleClickOutside(e: MouseEvent) {
             if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
                 setIsOpen(false);
             }
         }
+
+        // Close on Escape key
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape' && isOpen) {
+                setIsOpen(false);
+                buttonRef.current?.focus();
+            }
+        }
+
         document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [isOpen]);
 
     async function loadNotifications() {
         try {
@@ -78,9 +95,12 @@ export function NotificationBell() {
     return (
         <div className="relative" ref={dropdownRef}>
             <button
+                ref={buttonRef}
                 onClick={() => setIsOpen(!isOpen)}
                 className="relative p-2 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-white/10"
                 aria-label="Notifications"
+                aria-expanded={isOpen}
+                aria-haspopup="true"
             >
                 <Bell size={20} />
                 {unreadCount > 0 && (


### PR DESCRIPTION
This PR enhances the accessibility of the `NotificationBell` component by implementing standard keyboard interaction patterns.

**Changes:**
1.  **Close on Escape:** Users can now close the notification dropdown by pressing the `Escape` key.
2.  **Focus Management:** Focus is automatically restored to the bell button when the dropdown is closed via `Escape`, ensuring users don't lose their place.
3.  **ARIA Attributes:** Added `aria-expanded` and `aria-haspopup` to the toggle button for better screen reader support.
4.  **Refactoring:** Split the `useEffect` hook to correctly manage event listeners dependent on the open state.

**Verification:**
-   Verified functionality using a Playwright script (automated interaction test).
-   Confirmed that `Escape` closes the menu and restores focus.
-   Confirmed `aria-expanded` updates correctly.
-   Build passed (`pnpm build`).


---
*PR created automatically by Jules for task [12224524801869567375](https://jules.google.com/task/12224524801869567375) started by @PrinceJonaa*