### PR TITLE
🛡️ Sentinel: [HIGH] Secure tool execution by avoiding new Function

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** A server-side API key (`GEMINI_API_KEY`) was being injected into the client-side bundle via `vite.config.ts` using the `define` property. This effectively made the secret public to anyone inspecting the frontend code.
 **Learning:** Vite's `define` feature performs static replacement during the build. If you map a `process.env` variable to a value from the build environment, that value is hardcoded into the output JavaScript.
 **Prevention:** Never use `define` to inject secrets. Use `import.meta.env` with `VITE_` prefix only for intentionally public variables. For secrets, keep them strictly server-side (e.g., in Supabase Edge Functions) and proxy requests.
+
+## 2024-05-22 - Dynamic Tool Execution Scope Isolation
+**Vulnerability:** Tools were being executed via `new Function`, which creates a fresh scope. This caused tools relying on module-level constants (like `TEAM_DATA`) to fail because those variables were not injected into the execution context. It also presented a risk of Arbitrary Code Execution if tool definitions were compromised.
+**Learning:** `new Function` does not share the closure scope of the defining module. Dependencies must be explicitly injected or the original function reference must be used.
+**Prevention:** Avoid `new Function` for known, static tools. Store the function reference (`implementation`) in the tool definition and execute it directly to preserve closure access and improve security.

--- a/hooks/useGeminiAI.ts
+++ b/hooks/useGeminiAI.ts
@@ -379,7 +379,7 @@ ${recentContext}
                     if (setPage) { setPage(dest as Page); result = { success: true }; }
                   } else {
                     const toolDef = activeTools.find(t => t.name === call.name);
-                    if (toolDef) result = executeTool(toolDef.code, call.args);
+                    if (toolDef) result = executeTool(toolDef, call.args);
                   }
                   toolResultsRecord.push({ name: call.name, result });
                   toolOutputs.push({ functionResponse: { name: call.name, response: result } });

--- a/lib/aiTools.ts
+++ b/lib/aiTools.ts
@@ -885,7 +885,8 @@ export function getInitialTools(): ToolDefinition[] {
       parameters: JSON.stringify(decl.parameters, null, 2),
       code: code,
       enabled: true,
-      alwaysOn: false
+      alwaysOn: false,
+      implementation: fn
     };
   });
 }

--- a/lib/toolExecutor.ts
+++ b/lib/toolExecutor.ts
@@ -2,8 +2,33 @@
 import { db } from './mockDb';
 import * as frameworkEngine from './frameworkEngine';
 import { levenshteinDistance } from './aiTools';
+import { ToolDefinition } from '../types';
 
-export const executeTool = (code: string, args: any) => {
+export const executeTool = (tool: ToolDefinition | string, args: any) => {
+    // Check for implementation first
+    if (typeof tool !== 'string' && tool.implementation) {
+        console.log(`🔒 Executing tool '${tool.name}' securely via implementation reference`);
+        try {
+            const executionResult = tool.implementation(args);
+
+            // Parse result if it's a string json
+            if (typeof executionResult === 'string') {
+                try {
+                    return JSON.parse(executionResult);
+                } catch {
+                    return { result: executionResult };
+                }
+            }
+            return executionResult;
+        } catch (err: any) {
+            console.error("Tool Execution Error (Secure):", err);
+            return { error: err.message };
+        }
+    }
+
+    const code = typeof tool === 'string' ? tool : tool.code;
+    console.log("⚠️ Executing tool via dynamic evaluation");
+
     // Helper object containing all imports
     const utils = {
         analyzeJournalEntry: frameworkEngine.analyzeJournalEntry,

--- a/types.ts
+++ b/types.ts
@@ -263,6 +263,7 @@ export interface ToolDefinition {
   code: string; // Function body string
   enabled: boolean;
   alwaysOn?: boolean;
+  implementation?: (args: any) => any;
 }
 
 export interface ContactMessage {


### PR DESCRIPTION
This PR enhances the security and reliability of the AI tool execution engine.

Previously, all tools were converted to strings and executed using `new Function`. This had two major issues:
1.  **Security:** `new Function` evaluates code dynamically, which is a potential vector for XSS if tool definitions are tampered with (e.g. via local storage or external injection).
2.  **Reliability:** `new Function` creates a fresh scope. Tools that relied on module-level constants (like `get_team_contact` relying on `TEAM_DATA`) failed because those constants were not available in the dynamic scope.

**Changes:**
-   Updated `ToolDefinition` interface to include an optional `implementation` field (function reference).
-   Updated `getInitialTools` to attach the original function reference to the tool definition.
-   Refactored `executeTool` to check for `implementation`. If found, it executes the function directly (preserving closures and scope). If not, it falls back to the legacy `new Function` logic.
-   Updated `useGeminiAI` hook to pass the tool definition object instead of just the code string.

This change fixes the broken `get_team_contact` tool and significantly reduces the attack surface by avoiding dynamic evaluation for all built-in tools.

---
*PR created automatically by Jules for task [295018772594012258](https://jules.google.com/task/295018772594012258) started by @PrinceJonaa*