### PR TITLE
🎨 Palette: Improve NotificationBell accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - [Toast Accessibility & Visual Feedback]
 **Learning:** Standard toast notifications often lack intrinsic accessibility attributes (role, aria-live) and visual duration indicators, making them confusing for screen readers and cognitively demanding for sighted users who must guess when the message disappears.
 **Action:** Always couple auto-dismiss logic with a visual timer (progress bar) and strictly map toast types to semantic roles (error -> alert, info -> status) to ensure inclusive communication.
+
+## 2024-05-25 - [Contextual Action Labels in Lists]
+**Learning:** Generic action buttons in lists (like "Mark as read" or "Delete") are ambiguous for screen reader users navigating out of context (e.g., jumping between buttons).
+**Action:** Always append the item's unique identifier (title/name) to the `aria-label`, e.g., `aria-label="Mark [Notification Title] as read"`, to provide necessary context.

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -25,8 +25,20 @@ export function NotificationBell() {
                 setIsOpen(false);
             }
         }
+
+        // Close on Escape key
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape') {
+                setIsOpen(false);
+            }
+        }
+
         document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
     }, []);
 
     async function loadNotifications() {
@@ -116,7 +128,7 @@ export function NotificationBell() {
                         {/* Notifications List */}
                         <div className="max-h-80 overflow-y-auto">
                             {notifications.length === 0 ? (
-                                <div className="py-8 text-center text-gray-500">
+                                <div className="py-8 text-center text-gray-500" role="status">
                                     <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />
                                     <p className="text-sm">No notifications yet</p>
                                 </div>
@@ -150,8 +162,8 @@ export function NotificationBell() {
                                                         to={notif.link}
                                                         onClick={() => setIsOpen(false)}
                                                         className="p-1 text-gray-500 hover:text-accent"
-                                                        aria-label="Open link"
-                                                        title="Open link"
+                                                        aria-label={`Open link for ${notif.title}`}
+                                                        title={`Open link for ${notif.title}`}
                                                     >
                                                         <ExternalLink size={14} aria-hidden="true" />
                                                     </Link>
@@ -160,8 +172,8 @@ export function NotificationBell() {
                                                     <button
                                                         onClick={() => handleMarkAsRead(notif.id)}
                                                         className="p-1 text-gray-500 hover:text-green-400"
-                                                        title="Mark as read"
-                                                        aria-label="Mark as read"
+                                                        title={`Mark "${notif.title}" as read`}
+                                                        aria-label={`Mark "${notif.title}" as read`}
                                                     >
                                                         <Check size={14} aria-hidden="true" />
                                                     </button>


### PR DESCRIPTION
💡 What: Added Escape key support, contextual ARIA labels, and status role to NotificationBell.
🎯 Why: To improve accessibility for keyboard and screen reader users.
♿ Accessibility:
- Dropdown now closes on Escape key.
- Action buttons have contextual labels (e.g., "Mark [Title] as read").
- Empty state announces "No notifications yet" via role="status".

---
*PR created automatically by Jules for task [9817126894031915456](https://jules.google.com/task/9817126894031915456) started by @PrinceJonaa*