### PR TITLE
🎨 Palette: Improve Contact form accessibility

### DIFF
--- a/features/Contact.tsx
+++ b/features/Contact.tsx
@@ -6,23 +6,29 @@ import { Send, CheckCircle2, Loader2, Mail, MapPin, Clock, Globe, ArrowRight, Do
 import { useToast } from '../components/ToastSystem';
 import { submitContactMessage } from '../lib/supabase/contactService';
 
-const ContactInput = ({ label, value, onChange, placeholder, type = "text", disabled }: any) => (
-  <div className="group">
-    <label className="block text-[10px] font-mono text-gray-500 mb-2 uppercase tracking-widest group-focus-within:text-accent transition-colors">{label}</label>
-    <input 
-      type={type}
-      value={value}
-      onChange={onChange}
-      className="w-full bg-black/20 border border-white/10 rounded-xl py-3 px-4 focus:outline-none focus:border-accent/50 focus:bg-black/40 transition-all text-sm text-white placeholder-gray-700 hover:border-white/20" 
-      placeholder={placeholder}
-      disabled={disabled}
-    />
-  </div>
-);
+const ContactInput = ({ label, value, onChange, placeholder, type = "text", disabled }: any) => {
+  const id = React.useId();
+  return (
+    <div className="group">
+      <label htmlFor={id} className="block text-[10px] font-mono text-gray-500 mb-2 uppercase tracking-widest group-focus-within:text-accent transition-colors">{label}</label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={onChange}
+        className="w-full bg-black/20 border border-white/10 rounded-xl py-3 px-4 focus:outline-none focus:border-accent/50 focus:bg-black/40 transition-all text-sm text-white placeholder-gray-700 hover:border-white/20"
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    </div>
+  );
+};
 
 const SelectButton = ({ active, onClick, label, icon: Icon }: any) => (
   <button 
     type="button"
+    role="radio"
+    aria-checked={active}
     onClick={onClick}
     className={`flex items-center justify-center gap-2 py-3 px-4 rounded-xl border text-xs font-bold transition-all ${active ? 'bg-white text-black border-white' : 'bg-black/20 text-gray-400 border-white/10 hover:border-white/30 hover:text-white'}`}
   >
@@ -170,7 +176,7 @@ export const ContactSection = () => {
                     <div className="space-y-4">
                        <h4 className="text-xs font-bold text-accent uppercase tracking-widest flex items-center gap-2"><DollarSign size={14}/> Parameters</h4>
                        
-                       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2" role="radiogroup" aria-label="Budget">
                           {['Seed', 'Growth', 'Scale', 'Enterprise'].map((b) => (
                              <SelectButton 
                                 key={b} 
@@ -184,6 +190,7 @@ export const ContactSection = () => {
                        <div className="grid grid-cols-2 gap-2">
                            <div className="relative">
                               <select 
+                                aria-label="Project Timeline"
                                 value={formData.timeline}
                                 onChange={e => setFormData({...formData, timeline: e.target.value})}
                                 className="w-full bg-black/20 border border-white/10 rounded-xl py-3 px-4 appearance-none text-sm focus:border-accent/50 outline-none text-gray-300"
@@ -197,6 +204,7 @@ export const ContactSection = () => {
                            </div>
                            <div className="relative">
                               <select 
+                                aria-label="Project Category"
                                 value={formData.category}
                                 onChange={e => setFormData({...formData, category: e.target.value})}
                                 className="w-full bg-black/20 border border-white/10 rounded-xl py-3 px-4 appearance-none text-sm focus:border-accent/50 outline-none text-gray-300"
@@ -215,6 +223,7 @@ export const ContactSection = () => {
                     <div className="space-y-4">
                         <h4 className="text-xs font-bold text-accent uppercase tracking-widest flex items-center gap-2"><Clock size={14}/> The Signal</h4>
                         <textarea 
+                          aria-label="Message"
                           value={formData.message}
                           onChange={e => setFormData({...formData, message: e.target.value})}
                           className="w-full bg-black/20 border border-white/10 rounded-xl p-4 focus:outline-none focus:border-accent/50 transition-colors h-32 resize-none text-sm text-white placeholder-gray-700" 


### PR DESCRIPTION
💡 What:
- Refactored `ContactInput` to use `React.useId()` for robust label-input association.
- Updated `SelectButton` to use `role="radio"` and `aria-checked` to support the budget selection radio group.
- Added `aria-label` to the 'Timeline' and 'Category' selects and the 'Message' textarea.
- Added `role="radiogroup"` to the budget selection container.

🎯 Why:
- The previous implementation relied on visual cues for labels and selection states, making the form difficult or impossible to use for screen reader users.
- Missing labels for inputs and selects are a violation of WCAG 2.1 Success Criterion 3.3.2 (Labels or Instructions).

♿ Accessibility:
- Inputs are now properly announced with their labels.
- The budget selection now functions as an accessible radio group.
- All form controls have accessible names.

---
*PR created automatically by Jules for task [14491118484927019376](https://jules.google.com/task/14491118484927019376) started by @PrinceJonaa*