### PR TITLE
🎨 Palette: Notification dropdown accessibility improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - [Toast Accessibility & Visual Feedback]
 **Learning:** Standard toast notifications often lack intrinsic accessibility attributes (role, aria-live) and visual duration indicators, making them confusing for screen readers and cognitively demanding for sighted users who must guess when the message disappears.
 **Action:** Always couple auto-dismiss logic with a visual timer (progress bar) and strictly map toast types to semantic roles (error -> alert, info -> status) to ensure inclusive communication.
+
+## 2024-05-25 - [Dropdown Accessibility & Escape Key]
+**Learning:** Custom dropdowns often rely solely on "click outside" for dismissal, trapping keyboard users who cannot easily "click outside" and expect the Escape key to close the overlay.
+**Action:** Always pair "click outside" logic with a global `keydown` listener for the Escape key, and ensure the trigger button has `aria-expanded` and `aria-controls` linked to the dropdown's ID.

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -29,6 +29,17 @@ export function NotificationBell() {
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, []);
 
+    // Close on Escape key
+    useEffect(() => {
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape' && isOpen) {
+                setIsOpen(false);
+            }
+        }
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen]);
+
     async function loadNotifications() {
         try {
             const [notifs, count] = await Promise.all([
@@ -81,6 +92,9 @@ export function NotificationBell() {
                 onClick={() => setIsOpen(!isOpen)}
                 className="relative p-2 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-white/10"
                 aria-label="Notifications"
+                aria-expanded={isOpen}
+                aria-haspopup="dialog"
+                aria-controls="notification-panel"
             >
                 <Bell size={20} />
                 {unreadCount > 0 && (
@@ -93,6 +107,10 @@ export function NotificationBell() {
             <AnimatePresence>
                 {isOpen && (
                     <motion.div
+                        id="notification-panel"
+                        role="dialog"
+                        aria-label="Notifications"
+                        aria-modal="true"
                         initial={{ opacity: 0, y: -10, scale: 0.95 }}
                         animate={{ opacity: 1, y: 0, scale: 1 }}
                         exit={{ opacity: 0, y: -10, scale: 0.95 }}
@@ -150,8 +168,8 @@ export function NotificationBell() {
                                                         to={notif.link}
                                                         onClick={() => setIsOpen(false)}
                                                         className="p-1 text-gray-500 hover:text-accent"
-                                                        aria-label="Open link"
-                                                        title="Open link"
+                                                        aria-label={`Open link for ${notif.title}`}
+                                                        title={`Open link for ${notif.title}`}
                                                     >
                                                         <ExternalLink size={14} aria-hidden="true" />
                                                     </Link>
@@ -161,7 +179,7 @@ export function NotificationBell() {
                                                         onClick={() => handleMarkAsRead(notif.id)}
                                                         className="p-1 text-gray-500 hover:text-green-400"
                                                         title="Mark as read"
-                                                        aria-label="Mark as read"
+                                                        aria-label={`Mark ${notif.title} as read`}
                                                     >
                                                         <Check size={14} aria-hidden="true" />
                                                     </button>


### PR DESCRIPTION
💡 What:
- Added `Escape` key support to close the notification dropdown.
- Added ARIA attributes (`role='dialog'`, `aria-expanded`, `aria-controls`, `aria-modal`) for screen reader support.
- Added dynamic `aria-label` to notification action buttons (mark as read, open link) to provide context (e.g., 'Mark [Title] as read').

🎯 Why:
- The dropdown was inaccessible to keyboard users (could not be closed with Escape) and screen readers (lacked semantic roles).
- Action buttons were ambiguous ('Mark as read' repeated multiple times).

♿ Accessibility:
- Keyboard: Escape key now closes the dropdown.
- Screen Reader: Dropdown is announced as a dialog; actions are contextually described.

---
*PR created automatically by Jules for task [5570155764609681246](https://jules.google.com/task/5570155764609681246) started by @PrinceJonaa*